### PR TITLE
onEnable() and onDisable() should always override.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,15 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 	<properties>
 		<project.build.sourceEncoding>cp1252</project.build.sourceEncoding>

--- a/src/main/java/com/alessiodp/parties/Parties.java
+++ b/src/main/java/com/alessiodp/parties/Parties.java
@@ -94,6 +94,7 @@ public class Parties extends JavaPlugin {
 	
 	public static Parties getInstance() {return instance;}
 
+	@Override
 	public void onEnable() {
 		/* init */
 		instance = this;
@@ -105,6 +106,7 @@ public class Parties extends JavaPlugin {
 		LogHandler.log(1, "Parties v"+getDescription().getVersion()+" enabled");
 	}
 
+	@Override
 	public void onDisable() {
 		if(addon_DC != null)
 			addon_DC.disable();


### PR DESCRIPTION
Not sure why pom.xml got commited, but you need to override onEnable() and onDisable() or else the config will copy into all other plugins that do not override it.