### PR TITLE
Make spies not receive their own party's messages.

### DIFF
--- a/common/src/main/java/com/alessiodp/parties/common/players/spy/SpyManager.java
+++ b/common/src/main/java/com/alessiodp/parties/common/players/spy/SpyManager.java
@@ -38,7 +38,7 @@ public class SpyManager {
 		if (message.getMessage() != null && !message.getMessage().isEmpty()) {
 			UUID skip = message.getPlayer() != null ? message.getPlayer().getPlayerUUID() : null;
 			for (UUID uuid : spyList) {
-				if (!uuid.equals(skip)) {
+				if (!uuid.equals(skip) && !message.getParty().getMembers().contains(uuid)) {
 					User player = plugin.getPlayer(uuid);
 					if (player != null && player.hasPermission(PartiesPermission.ADMIN_SPY.toString())) {
 						player.sendMessage(message.toMessage(), false);


### PR DESCRIPTION
Spies can already see their own party's messages and therefore they
have no need to see them once more; one time is enough for some things
in life.